### PR TITLE
Buffer output before header and fix CSV filename

### DIFF
--- a/web/public/export_csv.php
+++ b/web/public/export_csv.php
@@ -1,7 +1,14 @@
 <?php
-require_once __DIR__ . '/config.php'; require_once __DIR__ . '/db.php'; $pdo=db();
-$report=$_GET['report'] ?? 'snapshot';
-header('Content-Type: text/csv'); header('Content-Disposition: attachment; filename="inventory_'+$report+'_'+date('Ymd_His')+'.csv"');
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/db.php';
+$pdo = db();
+$report = $_GET['report'] ?? 'snapshot';
+$allowed_reports = ['snapshot'];
+if (!in_array($report, $allowed_reports, true)) {
+    $report = 'snapshot';
+}
+header('Content-Type: text/csv');
+header('Content-Disposition: attachment; filename="inventory_' . $report . '_' . date('Ymd_His') . '.csv"');
 $out=fopen('php://output','w');
 if($report==='snapshot'){
   fputcsv($out,['SKU','Name','Unit','On Hand','Committed','Available']);

--- a/web/public/index.php
+++ b/web/public/index.php
@@ -1,8 +1,13 @@
 <?php
-require_once __DIR__ . '/config.php'; require_once __DIR__ . '/db.php';
-include __DIR__ . '/partials/header.php';
+ob_start();
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/db.php';
 $p = $_GET['p'] ?? 'dashboard';
 $allowed = ['dashboard','items','jobs','cycle_counts','reports'];
-if (!in_array($p, $allowed, true)) $p = 'dashboard';
+if (!in_array($p, $allowed, true)) {
+    $p = 'dashboard';
+}
+include __DIR__ . '/partials/header.php';
 include __DIR__ . "/pages/{$p}.php";
 include __DIR__ . '/partials/footer.php';
+ob_end_flush();


### PR DESCRIPTION
## Summary
- start output buffering in index.php so redirects and headers work before content is flushed
- validate report parameter and correctly build CSV export filename with string concatenation

## Testing
- `php -l web/public/index.php`
- `php -l web/public/export_csv.php`


------
https://chatgpt.com/codex/tasks/task_e_68b10345a9b88329911969c6f89d2448