### PR TITLE
Handle CSV import and add item edit buttons

### DIFF
--- a/web/public/pages/dashboard.php
+++ b/web/public/pages/dashboard.php
@@ -23,7 +23,8 @@ $items=$pdo->query("SELECT id, sku, name, unit, category, item_type, qty_on_hand
 <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
 <td class="text-end"><?= number_fmt($it['available']) ?></td>
 <td><?php if($short_onhand): ?><span class="badge badge-short">NEG On Hand</span><?php endif; ?><?php if($short_avail): ?><span class="badge text-bg-danger">Over-committed</span><?php endif; ?></td>
-<td><a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
+<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
+<a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
 <a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
 </tr>
 <?php endforeach; ?>

--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -50,9 +50,9 @@ $items=$pdo->query("SELECT * FROM inventory_items ORDER BY category, item_type, 
 <button class="btn btn-primary">Save</button></form></div></div></div>
 <div class="col-lg-7"><div class="card"><div class="card-body"><h2 class="h5">All Items</h2>
 <div class="table-responsive"><table class="table table-sm table-striped align-middle">
-<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th></tr></thead>
+<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th>Actions</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
 <td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><a href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>"><?= h($it['sku']) ?></a></td><td><?= h($it['name']) ?></td>
-<td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td><td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
+<td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td><td class="text-end"><?= number_fmt($it['qty_committed']) ?></td><td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a></td>
 </tr><?php endforeach; ?>
 </tbody></table></div></div></div></div></div>


### PR DESCRIPTION
## Summary
- Import items using fixed columns A-E from CSV
- Add edit buttons on dashboard and items pages

## Testing
- `php -l web/public/pages/import.php`
- `php -l web/public/pages/dashboard.php`
- `php -l web/public/pages/items.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3a6b214a48329abe09fa181079221