### PR TITLE
Add item archival and image support

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -8,11 +8,13 @@ CREATE TABLE IF NOT EXISTS inventory_items (
     item_type TEXT,
     item_use TEXT,
     description TEXT,
+    image_url TEXT,
     cost_usd NUMERIC(12,2) DEFAULT 0,
     sage_id VARCHAR(64),
     qty_on_hand NUMERIC(12,3) NOT NULL DEFAULT 0,
     qty_committed NUMERIC(12,3) NOT NULL DEFAULT 0,
     min_qty NUMERIC(12,3) DEFAULT 0,
+    archived BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT now(),
     updated_at TIMESTAMP DEFAULT now()
 );

--- a/web/public/pages/cycle_count_sheet.php
+++ b/web/public/pages/cycle_count_sheet.php
@@ -1,10 +1,10 @@
 <?php
 $pdo=db();
-$items=$pdo->query("SELECT i.category,i.item_type,i.sku,i.name,l.location FROM inventory_items i LEFT JOIN item_locations l ON l.item_id=i.id ORDER BY i.category,i.item_type,i.sku,l.location")->fetchAll();
+$items=$pdo->query("SELECT i.category,i.item_type,i.sku,i.name,i.image_url,l.location FROM inventory_items i LEFT JOIN item_locations l ON l.item_id=i.id WHERE i.archived=false ORDER BY i.category,i.item_type,i.sku,l.location")->fetchAll();
 ?>
 <h1 class="h3 mb-3">Cycle Count Worksheet</h1>
 <div class="table-responsive"><table class="table table-bordered">
-<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th>Location</th><th>Count</th></tr></thead>
+<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Img</th><th>Name</th><th>Location</th><th>Count</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
-<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><?= h($it['sku']) ?></td><td><?= h($it['name']) ?></td><td><?= h($it['location']) ?></td><td></td>
+<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><?= h($it['sku']) ?></td><td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;"><?php endif; ?></td><td><?= h($it['name']) ?></td><td><?= h($it['location']) ?></td><td></td>
 </tr><?php endforeach; ?></tbody></table></div>

--- a/web/public/pages/cycle_counts.php
+++ b/web/public/pages/cycle_counts.php
@@ -14,8 +14,8 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='cycle_coun
   }catch(Exception $e){ $pdo->rollBack(); throw $e; }
 }
 $item_id_prefill=isset($_GET['item_id'])?(int)$_GET['item_id']:null;
-$items=$pdo->query("SELECT id, sku, name FROM inventory_items ORDER BY sku")->fetchAll();
-$recent=$pdo->query("SELECT c.id,i.sku,i.name,c.counted_qty,c.count_date,c.note FROM cycle_counts c JOIN inventory_items i ON i.id=c.item_id ORDER BY c.id DESC LIMIT 20")->fetchAll();
+$items=$pdo->query("SELECT id, sku, name FROM inventory_items WHERE archived=false ORDER BY sku")->fetchAll();
+$recent=$pdo->query("SELECT c.id,i.sku,i.name,c.counted_qty,c.count_date,c.note FROM cycle_counts c JOIN inventory_items i ON i.id=c.item_id WHERE i.archived=false ORDER BY c.id DESC LIMIT 20")->fetchAll();
 ?>
 <div class="row g-3"><div class="col-lg-5"><div class="card"><div class="card-body">
 <h1 class="h5 mb-3">Cycle Count</h1>

--- a/web/public/pages/dashboard.php
+++ b/web/public/pages/dashboard.php
@@ -1,6 +1,6 @@
 <?php
 $pdo=db();
-$items=$pdo->query("SELECT id, sku, name, unit, category, item_type, qty_on_hand, qty_committed, (qty_on_hand - qty_committed) AS available FROM inventory_items ORDER BY category, item_type, sku")->fetchAll();
+$items=$pdo->query("SELECT id, sku, name, unit, category, item_type, image_url, qty_on_hand, qty_committed, (qty_on_hand - qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
 ?>
 <div class="d-flex justify-content-between align-items-center mb-3"><h1 class="h3 mb-0">Dashboard</h1>
 <div><a href="/index.php?p=items" class="btn btn-primary btn-sm">New Item</a>
@@ -18,7 +18,7 @@ $items=$pdo->query("SELECT id, sku, name, unit, category, item_type, qty_on_hand
 <?php } ?>
 <tr class="<?= ($short_onhand||$short_avail)?'table-danger':'' ?>">
 <td><?= h($it['sku']) ?></td>
-<td><?= h($it['name']) ?> <span class="text-secondary">(<?= h($it['unit']) ?>)</span></td>
+<td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;" class="me-1"><?php endif; ?><?= h($it['name']) ?> <span class="text-secondary">(<?= h($it['unit']) ?>)</span></td>
 <td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
 <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
 <td class="text-end"><?= number_fmt($it['available']) ?></td>

--- a/web/public/pages/item.php
+++ b/web/public/pages/item.php
@@ -8,7 +8,7 @@ if(!$item){ echo '<div class="alert alert-danger">Item not found</div>'; return;
 if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='update_item'){
   $pdo->beginTransaction();
   try{
-    $pdo->prepare("UPDATE inventory_items SET name=?,unit=?,category=?,item_type=?,item_use=?,description=?,cost_usd=?,sage_id=?,min_qty=? WHERE id=?")
+    $pdo->prepare("UPDATE inventory_items SET name=?,unit=?,category=?,item_type=?,item_use=?,description=?,image_url=?,cost_usd=?,sage_id=?,min_qty=?,archived=? WHERE id=?")
         ->execute([
           $_POST['name'],
           $_POST['unit']?:'ea',
@@ -16,9 +16,11 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='update_ite
           $_POST['item_type']?:null,
           $_POST['item_use']?:null,
           $_POST['description']?:null,
+          $_POST['image_url']?:null,
           (float)$_POST['cost_usd'],
           $_POST['sage_id']?:null,
           (float)$_POST['min_qty'],
+          isset($_POST['archived'])?1:0,
           $item['id']
         ]);
     $pdo->prepare("DELETE FROM item_locations WHERE item_id=?")->execute([$item['id']]);
@@ -51,8 +53,11 @@ $loc_text=implode("\n",$loc_lines);
 <div class="mb-2"><label class="form-label">Type</label><input name="item_type" class="form-control" value="<?= h($item['item_type']) ?>"></div>
 <div class="mb-2"><label class="form-label">Use</label><input name="item_use" class="form-control" value="<?= h($item['item_use']) ?>"></div>
 <div class="mb-2"><label class="form-label">Description</label><input name="description" class="form-control" value="<?= h($item['description']) ?>"></div>
+<div class="mb-2"><label class="form-label">Image URL</label><input name="image_url" class="form-control" value="<?= h($item['image_url']) ?>" placeholder="https://..."></div>
 <div class="mb-2"><label class="form-label">Cost (USD)</label><input name="cost_usd" type="number" step="0.01" class="form-control" value="<?= h($item['cost_usd']) ?>"></div>
 <div class="mb-2"><label class="form-label">Sage ID</label><input name="sage_id" class="form-control" value="<?= h($item['sage_id']) ?>"></div>
 <div class="mb-2"><label class="form-label">Locations (A.1.2.3=qty per line)</label><textarea name="locations" class="form-control" rows="3"><?= h($loc_text) ?></textarea></div>
 <div class="mb-2"><label class="form-label">Min Qty</label><input name="min_qty" type="number" step="0.001" class="form-control" value="<?= h($item['min_qty']) ?>"></div>
+<div class="form-check mb-3"><input class="form-check-input" type="checkbox" id="archived" name="archived" value="1" <?= $item['archived']?'checked':'' ?>>
+<label class="form-check-label" for="archived">Archived</label></div>
 <button class="btn btn-primary">Save</button></form></div></div>

--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -3,7 +3,7 @@ $pdo=db();
 if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='create_item'){
   $pdo->beginTransaction();
   try{
-    $stmt=$pdo->prepare("INSERT INTO inventory_items (sku,name,unit,category,item_type,item_use,description,cost_usd,sage_id,qty_on_hand,qty_committed,min_qty) VALUES (?,?,?,?,?,?,?,?,?,0,0,?)");
+    $stmt=$pdo->prepare("INSERT INTO inventory_items (sku,name,unit,category,item_type,item_use,description,image_url,cost_usd,sage_id,qty_on_hand,qty_committed,min_qty) VALUES (?,?,?,?,?,?,?,?,?,?,0,0,?)");
     $stmt->execute([
       $_POST['sku'],
       $_POST['name'],
@@ -12,6 +12,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='create_ite
       $_POST['item_type']?:null,
       $_POST['item_use']?:null,
       $_POST['description']?:null,
+      $_POST['image_url']?:null,
       (float)$_POST['cost_usd'],
       $_POST['sage_id']?:null,
       (float)$_POST['min_qty']
@@ -30,7 +31,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='create_ite
     header("Location: /index.php?p=items&created=1"); exit;
   }catch(Exception $e){ $pdo->rollBack(); throw $e; }
 }
-$items=$pdo->query("SELECT * FROM inventory_items ORDER BY category, item_type, sku")->fetchAll();
+$items=$pdo->query("SELECT * FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
 ?>
 <div class="d-flex justify-content-between align-items-center mb-3"><h1 class="h3 mb-0">Items</h1><a href="/index.php?p=import" class="btn btn-outline-primary btn-sm">Import CSV</a></div>
 <div class="row g-3"><div class="col-lg-5"><div class="card"><div class="card-body">
@@ -43,6 +44,7 @@ $items=$pdo->query("SELECT * FROM inventory_items ORDER BY category, item_type, 
 <div class="mb-2"><label class="form-label">Type</label><input name="item_type" class="form-control"></div>
 <div class="mb-2"><label class="form-label">Use</label><input name="item_use" class="form-control"></div>
 <div class="mb-2"><label class="form-label">Description</label><input name="description" class="form-control"></div>
+<div class="mb-2"><label class="form-label">Image URL</label><input name="image_url" class="form-control" placeholder="https://..."></div>
 <div class="mb-2"><label class="form-label">Cost (USD)</label><input name="cost_usd" type="number" step="0.01" class="form-control" value="0"></div>
 <div class="mb-2"><label class="form-label">Sage ID</label><input name="sage_id" class="form-control"></div>
 <div class="mb-2"><label class="form-label">Locations (A.1.2.3=qty per line)</label><textarea name="locations" class="form-control" rows="3" placeholder="A.1.2.3=5"></textarea></div>
@@ -50,9 +52,11 @@ $items=$pdo->query("SELECT * FROM inventory_items ORDER BY category, item_type, 
 <button class="btn btn-primary">Save</button></form></div></div></div>
 <div class="col-lg-7"><div class="card"><div class="card-body"><h2 class="h5">All Items</h2>
 <div class="table-responsive"><table class="table table-sm table-striped align-middle">
-<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th>Actions</th></tr></thead>
+<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Img</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th>Actions</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
-<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><a href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>"><?= h($it['sku']) ?></a></td><td><?= h($it['name']) ?></td>
+<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><a href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>"><?= h($it['sku']) ?></a></td>
+<td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;"><?php endif; ?></td>
+<td><?= h($it['name']) ?></td>
 <td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td><td class="text-end"><?= number_fmt($it['qty_committed']) ?></td><td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a></td>
 </tr><?php endforeach; ?>
 </tbody></table></div></div></div></div></div>

--- a/web/public/pages/jobs.php
+++ b/web/public/pages/jobs.php
@@ -87,7 +87,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='complete_j
     header("Location: /index.php?p=jobs&view=".$job_id."&done=1"); exit;
   }catch(Exception $e){ $pdo->rollBack(); $err=$e->getMessage(); }
 }
-$items=$pdo->query("SELECT id, sku, name FROM inventory_items ORDER BY sku")->fetchAll();
+$items=$pdo->query("SELECT id, sku, name FROM inventory_items WHERE archived=false ORDER BY sku")->fetchAll();
 $show_archived=isset($_GET['show_archived']);
 $job_stmt=$pdo->prepare("SELECT * FROM jobs".($show_archived?"":" WHERE archived=false")." ORDER BY created_at DESC LIMIT 50");
 $job_stmt->execute();

--- a/web/public/pages/reports.php
+++ b/web/public/pages/reports.php
@@ -1,6 +1,6 @@
 <?php
 $pdo=db();
-$items=$pdo->query("SELECT sku,name,unit,category,item_type,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items ORDER BY category, item_type, sku")->fetchAll();
+$items=$pdo->query("SELECT sku,name,unit,category,item_type,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
 ?>
 <div class="d-flex justify-content-between align-items-center mb-3"><h1 class="h3 mb-0">Reports</h1>
 <div class="d-flex gap-2"><a class="btn btn-outline-primary btn-sm" href="/export_csv.php?report=snapshot">Export CSV</a>


### PR DESCRIPTION
## Summary
- allow inventory items to be marked as archived and exclude them from lists and reports
- permit storing an image URL for each item and display icons in lists and cycle count sheets
- extend item edit and creation forms to handle image URLs and archiving

## Testing
- `php -l web/public/pages/items.php`
- `php -l web/public/pages/item.php`
- `php -l web/public/pages/dashboard.php`
- `php -l web/public/pages/cycle_count_sheet.php`
- `php -l web/public/pages/jobs.php`
- `php -l web/public/pages/cycle_counts.php`
- `php -l web/public/pages/reports.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3acca940c83298722be8f02ae8b87