### PR TITLE
Move item deletion to detail page and support image uploads

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -2,11 +2,13 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE IF NOT EXISTS inventory_items (
     id SERIAL PRIMARY KEY,
     sku VARCHAR(64) UNIQUE NOT NULL,
+    parent_sku VARCHAR(64),
     name TEXT NOT NULL,
     unit VARCHAR(16) DEFAULT 'ea',
     category TEXT,
     item_type TEXT,
     item_use TEXT,
+    finish TEXT,
     description TEXT,
     image_url TEXT,
     cost_usd NUMERIC(12,2) DEFAULT 0,

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -1,1 +1,49 @@
-(function(){const t=document.getElementById('themeSwitch');function s(e){document.documentElement.setAttribute('data-bs-theme',e),localStorage.setItem('theme',e)}const a=localStorage.getItem('theme')||'dark';s(a),t&&(t.checked=a==='light',t.addEventListener('change',()=>s(t.checked?'light':'dark')));window.exportTableToPDF=function(e,n){const{ jsPDF:o }=window.jspdf,d=new o({orientation:'landscape',unit:'pt',format:'letter'}),l=document.getElementById(e);if(!l)return alert('Table not found');let r=40;d.setFontSize(14),d.text(n||'Inventory Report',40,r),r+=20;const i=[],c=[];l.querySelectorAll('thead th').forEach(h=>c.push(h.innerText.trim())),l.querySelectorAll('tbody tr').forEach(h=>{const m=[];h.querySelectorAll('td').forEach(u=>m.push(u.innerText.trim())),i.push(m)});const f=150;let p=40;c.forEach((h,m)=>{d.text(h,p+m*f,r)}),r+=14,i.forEach(h=>{h.forEach((m,u)=>d.text(String(m),p+u*f,r)),r+=14,r>540&&(d.addPage(),r=40)}),d.save((n||'report')+'.pdf')}})();
+(function(){
+  const themeSwitch = document.getElementById('themeSwitch');
+  function setTheme(theme){
+    document.documentElement.setAttribute('data-bs-theme', theme);
+    localStorage.setItem('theme', theme);
+  }
+  const initial = localStorage.getItem('theme') || 'dark';
+  setTheme(initial);
+  if(themeSwitch){
+    themeSwitch.checked = initial === 'light';
+    themeSwitch.addEventListener('change', ()=> setTheme(themeSwitch.checked ? 'light' : 'dark'));
+  }
+
+  window.exportTableToPDF = function(tableId, title){
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'letter'});
+    const table = document.getElementById(tableId);
+    if(!table) return alert('Table not found');
+    let y = 40;
+    doc.setFontSize(16);
+    doc.text(title || 'Inventory Report', 40, y);
+    y += 20;
+    const headers = [];
+    table.querySelectorAll('thead th').forEach(th => headers.push(th.innerText.trim()));
+    const rows = [];
+    table.querySelectorAll('tbody tr').forEach(tr => {
+      const row = [];
+      tr.querySelectorAll('td').forEach(td => row.push(td.innerText.trim()));
+      rows.push(row);
+    });
+    const colWidth = 720 / headers.length;
+    doc.setFont('helvetica','bold');
+    headers.forEach((h,i)=> doc.text(h, 40 + i*colWidth, y));
+    doc.line(40, y+2, 40 + headers.length*colWidth, y+2);
+    y += 14;
+    doc.setFont('helvetica','normal');
+    rows.forEach(r => {
+      r.forEach((cell,i)=> doc.text(String(cell), 40 + i*colWidth, y));
+      doc.line(40, y+2, 40 + headers.length*colWidth, y+2);
+      y += 14;
+      if(y > 540){
+        doc.addPage();
+        y = 40;
+      }
+    });
+    doc.save((title || 'report') + '.pdf');
+  };
+})();
+

--- a/web/public/export_csv.php
+++ b/web/public/export_csv.php
@@ -2,17 +2,33 @@
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/db.php';
 $pdo = db();
-$report = $_GET['report'] ?? 'snapshot';
-$allowed_reports = ['snapshot'];
+$report = $_GET['report'] ?? 'full';
+$allowed_reports = ['full','low','accounting'];
 if (!in_array($report, $allowed_reports, true)) {
-    $report = 'snapshot';
+    $report = 'full';
 }
 header('Content-Type: text/csv');
 header('Content-Disposition: attachment; filename="inventory_' . $report . '_' . date('Ymd_His') . '.csv"');
 $out=fopen('php://output','w');
-if($report==='snapshot'){
+if($report==='full'){
   fputcsv($out,['SKU','Name','Unit','On Hand','Committed','Available']);
-  $stmt=$pdo->query("SELECT sku,name,unit,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items ORDER BY sku");
-  while($row=$stmt->fetch(PDO::FETCH_ASSOC)){ fputcsv($out,[$row['sku'],$row['name'],$row['unit'],$row['qty_on_hand'],$row['qty_committed'],$row['available']]); }
-}else{ fputcsv($out,['Unsupported report']); }
+  $stmt=$pdo->query("SELECT sku,name,unit,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY sku");
+  while($row=$stmt->fetch(PDO::FETCH_ASSOC)){
+      fputcsv($out,[$row['sku'],$row['name'],$row['unit'],$row['qty_on_hand'],$row['qty_committed'],$row['available']]);
+  }
+}elseif($report==='low'){
+  fputcsv($out,['SKU','Name','Min Qty','Available']);
+  $stmt=$pdo->query("SELECT sku,name,min_qty,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false AND min_qty IS NOT NULL AND (qty_on_hand-qty_committed) < min_qty ORDER BY available ASC");
+  while($row=$stmt->fetch(PDO::FETCH_ASSOC)){
+      fputcsv($out,[$row['sku'],$row['name'],$row['min_qty'],$row['available']]);
+  }
+}elseif($report==='accounting'){
+  fputcsv($out,['SKU','Name','Unit','Cost USD','On Hand','Value']);
+  $stmt=$pdo->query("SELECT sku,name,unit,cost_usd,qty_on_hand,(cost_usd*qty_on_hand) AS total FROM inventory_items WHERE archived=false ORDER BY sku");
+  while($row=$stmt->fetch(PDO::FETCH_ASSOC)){
+      fputcsv($out,[$row['sku'],$row['name'],$row['unit'],$row['cost_usd'],$row['qty_on_hand'],$row['total']]);
+  }
+}else{
+  fputcsv($out,['Unsupported report']);
+}
 fclose($out); exit;

--- a/web/public/export_csv.php
+++ b/web/public/export_csv.php
@@ -12,19 +12,19 @@ header('Content-Disposition: attachment; filename="inventory_' . $report . '_' .
 $out=fopen('php://output','w');
 if($report==='full'){
   fputcsv($out,['SKU','Name','Unit','On Hand','Committed','Available']);
-  $stmt=$pdo->query("SELECT sku,name,unit,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY sku");
+  $stmt=$pdo->query("SELECT base_sku AS sku, MIN(name) AS name, MIN(unit) AS unit, SUM(qty_on_hand) AS qty_on_hand, SUM(qty_committed) AS qty_committed, SUM(qty_on_hand-qty_committed) AS available FROM (SELECT COALESCE(parent_sku,sku) AS base_sku, name, unit, qty_on_hand, qty_committed FROM inventory_items WHERE archived=false) t GROUP BY base_sku ORDER BY base_sku");
   while($row=$stmt->fetch(PDO::FETCH_ASSOC)){
       fputcsv($out,[$row['sku'],$row['name'],$row['unit'],$row['qty_on_hand'],$row['qty_committed'],$row['available']]);
   }
 }elseif($report==='low'){
   fputcsv($out,['SKU','Name','Min Qty','Available']);
-  $stmt=$pdo->query("SELECT sku,name,min_qty,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false AND min_qty IS NOT NULL AND (qty_on_hand-qty_committed) < min_qty ORDER BY available ASC");
+  $stmt=$pdo->query("SELECT base_sku AS sku, MIN(name) AS name, MIN(min_qty) AS min_qty, SUM(qty_on_hand-qty_committed) AS available FROM (SELECT COALESCE(parent_sku,sku) AS base_sku, name, min_qty, qty_on_hand, qty_committed FROM inventory_items WHERE archived=false) t GROUP BY base_sku HAVING SUM(qty_on_hand-qty_committed) < MIN(min_qty) ORDER BY available ASC");
   while($row=$stmt->fetch(PDO::FETCH_ASSOC)){
       fputcsv($out,[$row['sku'],$row['name'],$row['min_qty'],$row['available']]);
   }
 }elseif($report==='accounting'){
   fputcsv($out,['SKU','Name','Unit','Cost USD','On Hand','Value']);
-  $stmt=$pdo->query("SELECT sku,name,unit,cost_usd,qty_on_hand,(cost_usd*qty_on_hand) AS total FROM inventory_items WHERE archived=false ORDER BY sku");
+  $stmt=$pdo->query("SELECT base_sku AS sku, MIN(name) AS name, MIN(unit) AS unit, MIN(cost_usd) AS cost_usd, SUM(qty_on_hand) AS qty_on_hand, SUM(cost_usd*qty_on_hand) AS total FROM (SELECT COALESCE(parent_sku,sku) AS base_sku, name, unit, cost_usd, qty_on_hand FROM inventory_items WHERE archived=false) t GROUP BY base_sku ORDER BY base_sku");
   while($row=$stmt->fetch(PDO::FETCH_ASSOC)){
       fputcsv($out,[$row['sku'],$row['name'],$row['unit'],$row['cost_usd'],$row['qty_on_hand'],$row['total']]);
   }

--- a/web/public/index.php
+++ b/web/public/index.php
@@ -3,7 +3,7 @@ ob_start();
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/db.php';
 $p = $_GET['p'] ?? 'dashboard';
-$allowed = ['dashboard','items','item','jobs','cycle_counts','reports','import','settings','cycle_count_sheet','cycle_count_import'];
+$allowed = ['dashboard','items','item','jobs','cycle_counts','reports','report_designer','import','settings','cycle_count_sheet','cycle_count_import'];
 if (!in_array($p, $allowed, true)) {
     $p = 'dashboard';
 }

--- a/web/public/modules/counts_due.php
+++ b/web/public/modules/counts_due.php
@@ -1,0 +1,6 @@
+<?php
+?>
+<div class="card mb-3"><div class="card-body">
+<h2 class="h5 mb-0">Counts Due</h2>
+<p class="mb-0 text-secondary">Module placeholder.</p>
+</div></div>

--- a/web/public/modules/low_stock.php
+++ b/web/public/modules/low_stock.php
@@ -1,0 +1,18 @@
+<?php
+$items=$pdo->query("SELECT id, sku, name, (qty_on_hand - qty_committed) AS available, min_qty FROM inventory_items WHERE archived=false AND min_qty IS NOT NULL AND (qty_on_hand - qty_committed) < min_qty ORDER BY available ASC LIMIT 10")->fetchAll();
+?>
+<div class="card mb-3"><div class="card-body">
+<h2 class="h5 mb-3">Low Stock Parts</h2>
+<?php if($items): ?>
+<ul class="list-group list-group-flush">
+<?php foreach($items as $it): ?>
+<li class="list-group-item d-flex justify-content-between align-items-center">
+<span><?= h($it['sku']).' - '.h($it['name']) ?></span>
+<span class="badge text-bg-danger"><?= number_fmt($it['available']) ?>/<?= number_fmt($it['min_qty']) ?></span>
+</li>
+<?php endforeach; ?>
+</ul>
+<?php else: ?>
+<p class="mb-0 text-secondary">No low stock parts.</p>
+<?php endif; ?>
+</div></div>

--- a/web/public/modules/low_stock.php
+++ b/web/public/modules/low_stock.php
@@ -1,5 +1,5 @@
 <?php
-$items=$pdo->query("SELECT id, sku, name, (qty_on_hand - qty_committed) AS available, min_qty FROM inventory_items WHERE archived=false AND min_qty IS NOT NULL AND (qty_on_hand - qty_committed) < min_qty ORDER BY available ASC LIMIT 10")->fetchAll();
+$items=$pdo->query("SELECT base_sku AS sku, MIN(name) AS name, MIN(min_qty) AS min_qty, SUM(qty_on_hand-qty_committed) AS available FROM (SELECT COALESCE(parent_sku,sku) AS base_sku, name, min_qty, qty_on_hand, qty_committed FROM inventory_items WHERE archived=false) t GROUP BY base_sku HAVING MIN(min_qty) IS NOT NULL AND SUM(qty_on_hand-qty_committed) < MIN(min_qty) ORDER BY available ASC LIMIT 10")->fetchAll();
 ?>
 <div class="card mb-3"><div class="card-body">
 <h2 class="h5 mb-3">Low Stock Parts</h2>

--- a/web/public/modules/parts_list.php
+++ b/web/public/modules/parts_list.php
@@ -1,6 +1,11 @@
 <?php
 $display=$pdo->query("SELECT value FROM settings WHERE key='dashboard_display'")->fetchColumn() ?: 'grouped';
-$items=$pdo->query("SELECT id, sku, name, unit, category, item_type, image_url, qty_on_hand, qty_committed, (qty_on_hand - qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
+$variantView=$pdo->query("SELECT value FROM settings WHERE key='variant_view'")->fetchColumn() ?: 'individual';
+if($variantView==='grouped'){
+  $items=$pdo->query("SELECT MIN(id) AS id, COALESCE(parent_sku,sku) AS sku, MIN(name) AS name, MIN(unit) AS unit, MIN(category) AS category, MIN(item_type) AS item_type, MIN(image_url) AS image_url, SUM(qty_on_hand) AS qty_on_hand, SUM(qty_committed) AS qty_committed, SUM(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false GROUP BY COALESCE(parent_sku,sku) ORDER BY MIN(category), MIN(item_type), sku")->fetchAll();
+}else{
+  $items=$pdo->query("SELECT id, sku, name, unit, category, item_type, image_url, qty_on_hand, qty_committed, (qty_on_hand - qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
+}
 ?>
 <div class="card mb-3"><div class="card-body">
 <h2 class="h5 mb-3">Parts List</h2>

--- a/web/public/modules/parts_list.php
+++ b/web/public/modules/parts_list.php
@@ -1,0 +1,51 @@
+<?php
+$display=$pdo->query("SELECT value FROM settings WHERE key='dashboard_display'")->fetchColumn() ?: 'grouped';
+$items=$pdo->query("SELECT id, sku, name, unit, category, item_type, image_url, qty_on_hand, qty_committed, (qty_on_hand - qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
+?>
+<div class="card mb-3"><div class="card-body">
+<h2 class="h5 mb-3">Parts List</h2>
+<?php if($display==='table'): ?>
+<div class="table-responsive"><table class="table table-striped table-hover align-middle">
+<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th class="text-end">Available</th><th>Actions</th></tr></thead>
+<tbody>
+<?php foreach($items as $it): $short_onhand=((float)$it['qty_on_hand'])<0; $short_avail=((float)$it['available'])<0; ?>
+<tr class="<?= ($short_onhand||$short_avail)?'table-danger':'' ?>">
+<td><?= h($it['category']) ?></td>
+<td><?= h($it['item_type']) ?></td>
+<td><?= h($it['sku']) ?></td>
+<td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;" class="me-1"><?php endif; ?><?= h($it['name']) ?> <span class="text-secondary">(<?= h($it['unit']) ?>)</span></td>
+<td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
+<td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
+<td class="text-end"><?= number_fmt($it['available']) ?></td>
+<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
+<a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
+<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
+</tr>
+<?php endforeach; ?>
+</tbody></table></div>
+<?php else: ?>
+<div class="table-responsive"><table class="table table-striped table-hover align-middle">
+<thead><tr><th>SKU</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th class="text-end">Available</th><th>Status</th><th>Actions</th></tr></thead>
+<tbody>
+<?php $curCat=null; $curType=null; foreach($items as $it): $short_onhand=((float)$it['qty_on_hand'])<0; $short_avail=((float)$it['available'])<0; ?>
+<?php if($it['category']!==$curCat){ $curCat=$it['category']; $curType=null; ?>
+<tr class="table-secondary"><th colspan="7"><?= h($curCat) ?></th></tr>
+<?php } ?>
+<?php if($it['item_type']!==$curType){ $curType=$it['item_type']; ?>
+<tr class="table-light"><th colspan="7" class="ps-4"><?= h($curType) ?></th></tr>
+<?php } ?>
+<tr class="<?= ($short_onhand||$short_avail)?'table-danger':'' ?>">
+<td><?= h($it['sku']) ?></td>
+<td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;" class="me-1"><?php endif; ?><?= h($it['name']) ?> <span class="text-secondary">(<?= h($it['unit']) ?>)</span></td>
+<td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
+<td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
+<td class="text-end"><?= number_fmt($it['available']) ?></td>
+<td><?php if($short_onhand): ?><span class="badge badge-short">NEG On Hand</span><?php endif; ?><?php if($short_avail): ?><span class="badge text-bg-danger">Over-committed</span><?php endif; ?></td>
+<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
+<a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
+<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
+</tr>
+<?php endforeach; ?>
+</tbody></table></div>
+<?php endif; ?>
+</div></div>

--- a/web/public/pages/dashboard.php
+++ b/web/public/pages/dashboard.php
@@ -1,31 +1,15 @@
 <?php
 $pdo=db();
-$items=$pdo->query("SELECT id, sku, name, unit, category, item_type, image_url, qty_on_hand, qty_committed, (qty_on_hand - qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
+$mods=$pdo->query("SELECT value FROM settings WHERE key='dashboard_modules'")->fetchColumn();
+$mods=$mods?array_filter(explode(',', $mods)):['parts_list'];
 ?>
 <div class="d-flex justify-content-between align-items-center mb-3"><h1 class="h3 mb-0">Dashboard</h1>
 <div><a href="/index.php?p=items" class="btn btn-primary btn-sm">New Item</a>
 <a href="/index.php?p=jobs" class="btn btn-outline-secondary btn-sm">Jobs</a>
 <a href="/index.php?p=cycle_counts" class="btn btn-outline-secondary btn-sm">Cycle Counts</a></div></div>
-<div class="card"><div class="card-body"><div class="table-responsive"><table class="table table-striped table-hover align-middle">
-<thead><tr><th>SKU</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th class="text-end">Available</th><th>Status</th><th>Actions</th></tr></thead>
-<tbody>
-<?php $curCat=null; $curType=null; foreach($items as $it): $short_onhand=((float)$it['qty_on_hand'])<0; $short_avail=((float)$it['available'])<0; ?>
-<?php if($it['category']!==$curCat){ $curCat=$it['category']; $curType=null; ?>
-<tr class="table-secondary"><th colspan="7"><?= h($curCat) ?></th></tr>
-<?php } ?>
-<?php if($it['item_type']!==$curType){ $curType=$it['item_type']; ?>
-<tr class="table-light"><th colspan="7" class="ps-4"><?= h($curType) ?></th></tr>
-<?php } ?>
-<tr class="<?= ($short_onhand||$short_avail)?'table-danger':'' ?>">
-<td><?= h($it['sku']) ?></td>
-<td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;" class="me-1"><?php endif; ?><?= h($it['name']) ?> <span class="text-secondary">(<?= h($it['unit']) ?>)</span></td>
-<td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
-<td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
-<td class="text-end"><?= number_fmt($it['available']) ?></td>
-<td><?php if($short_onhand): ?><span class="badge badge-short">NEG On Hand</span><?php endif; ?><?php if($short_avail): ?><span class="badge text-bg-danger">Over-committed</span><?php endif; ?></td>
-<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
-<a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
-<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
-</tr>
-<?php endforeach; ?>
-</tbody></table></div></div></div>
+<?php
+foreach($mods as $m){
+  $file=__DIR__.'/../modules/'.basename($m).'.php';
+  if(is_file($file)) include $file;
+}
+?>

--- a/web/public/pages/item.php
+++ b/web/public/pages/item.php
@@ -42,7 +42,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
       $locations=preg_split('/\r?\n/', trim($_POST['locations']??''));
       foreach($locations as $line){
         $line=trim($line); if($line==='') continue;
-        if(!preg_match('/^([A-Z]\.\d+\.\d+\.\d+)=(\d+(?:\.\d+)?)$/',$line,$m)) continue;
+        if(!preg_match('/^([A-Z]\.\d+\.\d+)=(\d+(?:\.\d+)?)$/',$line,$m)) continue;
         $pdo->prepare("INSERT INTO item_locations (item_id,location,qty_on_hand) VALUES (?,?,?)")
             ->execute([$item['id'],$m[1],$m[2]]);
         $total+=$m[2];
@@ -74,7 +74,7 @@ $loc_text=implode("\n",$loc_lines);
 <div class="mb-2"><label class="form-label">Image</label><input type="file" name="image_file" class="form-control"><?php if($item['image_url']): ?><img src="<?= h($item['image_url']) ?>" alt="" class="img-thumbnail mt-2" style="width:80px;height:80px;object-fit:cover;"><?php endif; ?></div>
 <div class="mb-2"><label class="form-label">Cost (USD)</label><input name="cost_usd" type="number" step="0.01" class="form-control" value="<?= h($item['cost_usd']) ?>"></div>
 <div class="mb-2"><label class="form-label">Sage ID</label><input name="sage_id" class="form-control" value="<?= h($item['sage_id']) ?>"></div>
-<div class="mb-2"><label class="form-label">Locations (A.1.2.3=qty per line)</label><textarea name="locations" class="form-control" rows="3"><?= h($loc_text) ?></textarea></div>
+<div class="mb-2"><label class="form-label">Locations (A.1.2=qty per line)</label><textarea name="locations" class="form-control" rows="3"><?= h($loc_text) ?></textarea></div>
 <div class="mb-2"><label class="form-label">Min Qty</label><input name="min_qty" type="number" step="0.001" class="form-control" value="<?= h($item['min_qty']) ?>"></div>
 <div class="form-check mb-3"><input class="form-check-input" type="checkbox" id="archived" name="archived" value="1" <?= $item['archived']?'checked':'' ?>>
 <label class="form-check-label" for="archived">Archived</label></div>

--- a/web/public/pages/item.php
+++ b/web/public/pages/item.php
@@ -22,8 +22,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
           $image_url='/uploads/'.$fname;
         }
       }
-      $pdo->prepare("UPDATE inventory_items SET name=?,unit=?,category=?,item_type=?,item_use=?,description=?,image_url=?,cost_usd=?,sage_id=?,min_qty=?,archived=? WHERE id=?")
+      $pdo->prepare("UPDATE inventory_items SET parent_sku=?, finish=?, name=?,unit=?,category=?,item_type=?,item_use=?,description=?,image_url=?,cost_usd=?,sage_id=?,min_qty=?,archived=? WHERE id=?")
           ->execute([
+            $_POST['parent_sku']?:null,
+            $_POST['finish']?:null,
             $_POST['name'],
             $_POST['unit']?:'ea',
             $_POST['category']?:null,
@@ -65,6 +67,8 @@ $loc_text=implode("\n",$loc_lines);
 <?php if(isset($_GET['updated'])): ?><div class="alert alert-success">Item updated</div><?php endif; ?>
 <div class="card"><div class="card-body"><form method="post" enctype="multipart/form-data"><input type="hidden" name="form" value="update_item">
 <div class="mb-2"><label class="form-label">SKU</label><input name="sku" class="form-control" value="<?= h($item['sku']) ?>" readonly></div>
+<div class="mb-2"><label class="form-label">Parent SKU (optional)</label><input name="parent_sku" class="form-control" value="<?= h($item['parent_sku']) ?>"></div>
+<div class="mb-2"><label class="form-label">Finish</label><input name="finish" class="form-control" value="<?= h($item['finish']) ?>"></div>
 <div class="mb-2"><label class="form-label">Name</label><input name="name" class="form-control" value="<?= h($item['name']) ?>" required></div>
 <div class="mb-2"><label class="form-label">Unit</label><input name="unit" class="form-control" value="<?= h($item['unit']) ?>"></div>
 <div class="mb-2"><label class="form-label">Category</label><input name="category" class="form-control" value="<?= h($item['category']) ?>"></div>

--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -36,7 +36,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
       $locations=preg_split('/\r?\n/', trim($_POST['locations']??''));
       foreach($locations as $line){
         $line=trim($line); if($line==='') continue;
-        if(!preg_match('/^([A-Z]\.\d+\.\d+\.\d+)=(\d+(?:\.\d+)?)$/',$line,$m)) continue;
+        if(!preg_match('/^([A-Z]\.\d+\.\d+)=(\d+(?:\.\d+)?)$/',$line,$m)) continue;
         $pdo->prepare("INSERT INTO item_locations (item_id,location,qty_on_hand) VALUES (?,?,?)")->execute([$item_id,$m[1],$m[2]]);
         $total+=$m[2];
       }
@@ -100,7 +100,7 @@ $items=$pdo->query("SELECT * FROM inventory_items WHERE archived=false ORDER BY 
           <div class="mb-2"><label class="form-label">Image</label><input type="file" name="image_file" class="form-control"></div>
           <div class="mb-2"><label class="form-label">Cost (USD)</label><input name="cost_usd" type="number" step="0.01" class="form-control" value="0"></div>
           <div class="mb-2"><label class="form-label">Sage ID</label><input name="sage_id" class="form-control"></div>
-          <div class="mb-2"><label class="form-label">Locations (A.1.2.3=qty per line)</label><textarea name="locations" class="form-control" rows="3" placeholder="A.1.2.3=5"></textarea></div>
+          <div class="mb-2"><label class="form-label">Locations (A.1.2=qty per line)</label><textarea name="locations" class="form-control" rows="3" placeholder="A.1.2=5"></textarea></div>
           <div class="mb-2"><label class="form-label">Min Qty (optional)</label><input name="min_qty" type="number" step="0.001" class="form-control" value="0"></div>
         </div>
         <div class="modal-footer">

--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -3,61 +3,60 @@ $pdo=db();
 if($_SERVER['REQUEST_METHOD']==='POST'){
   $form=$_POST['form']??'';
   if($form==='create_item'){
-  $pdo->beginTransaction();
-  try{
-    $stmt=$pdo->prepare("INSERT INTO inventory_items (sku,name,unit,category,item_type,item_use,description,image_url,cost_usd,sage_id,qty_on_hand,qty_committed,min_qty) VALUES (?,?,?,?,?,?,?,?,?,?,0,0,?)");
-    $stmt->execute([
-      $_POST['sku'],
-      $_POST['name'],
-      $_POST['unit']?:'ea',
-      $_POST['category']?:null,
-      $_POST['item_type']?:null,
-      $_POST['item_use']?:null,
-      $_POST['description']?:null,
-      $_POST['image_url']?:null,
-      (float)$_POST['cost_usd'],
-      $_POST['sage_id']?:null,
-      (float)$_POST['min_qty']
-    ]);
-    $item_id=$pdo->lastInsertId();
-    $total=0;
-    $locations=preg_split('/\r?\n/', trim($_POST['locations']??''));
-    foreach($locations as $line){
-      $line=trim($line); if($line==='') continue;
-      if(!preg_match('/^([A-Z]\.\d+\.\d+\.\d+)=(\d+(?:\.\d+)?)$/',$line,$m)) continue;
-      $pdo->prepare("INSERT INTO item_locations (item_id,location,qty_on_hand) VALUES (?,?,?)")->execute([$item_id,$m[1],$m[2]]);
-      $total+=$m[2];
-    }
-    $pdo->prepare("UPDATE inventory_items SET qty_on_hand=? WHERE id=?")->execute([$total,$item_id]);
-    $pdo->commit();
-    header("Location: /index.php?p=items&created=1"); exit;
-  }catch(Exception $e){ $pdo->rollBack(); throw $e; }
-  }elseif($form==='delete_item'){
-    $pdo->prepare("DELETE FROM inventory_items WHERE id=?")->execute([(int)$_POST['item_id']]);
-    header("Location: /index.php?p=items&deleted=1"); exit;
+    $pdo->beginTransaction();
+    try{
+      $image_url=null;
+      if(!empty($_FILES['image_file']['tmp_name'])){
+        $img=@imagecreatefromstring(file_get_contents($_FILES['image_file']['tmp_name']));
+        if($img){
+          $dir=dirname(__DIR__).'/uploads';
+          if(!is_dir($dir)) mkdir($dir,0777,true);
+          $fname=uniqid().'.jpg';
+          imagejpeg($img,$dir.'/'.$fname);
+          imagedestroy($img);
+          $image_url='/uploads/'.$fname;
+        }
+      }
+      $stmt=$pdo->prepare("INSERT INTO inventory_items (sku,name,unit,category,item_type,item_use,description,image_url,cost_usd,sage_id,qty_on_hand,qty_committed,min_qty) VALUES (?,?,?,?,?,?,?,?,?,?,0,0,?)");
+      $stmt->execute([
+        $_POST['sku'],
+        $_POST['name'],
+        $_POST['unit']?:'ea',
+        $_POST['category']?:null,
+        $_POST['item_type']?:null,
+        $_POST['item_use']?:null,
+        $_POST['description']?:null,
+        $image_url,
+        (float)$_POST['cost_usd'],
+        $_POST['sage_id']?:null,
+        (float)$_POST['min_qty']
+      ]);
+      $item_id=$pdo->lastInsertId();
+      $total=0;
+      $locations=preg_split('/\r?\n/', trim($_POST['locations']??''));
+      foreach($locations as $line){
+        $line=trim($line); if($line==='') continue;
+        if(!preg_match('/^([A-Z]\.\d+\.\d+\.\d+)=(\d+(?:\.\d+)?)$/',$line,$m)) continue;
+        $pdo->prepare("INSERT INTO item_locations (item_id,location,qty_on_hand) VALUES (?,?,?)")->execute([$item_id,$m[1],$m[2]]);
+        $total+=$m[2];
+      }
+      $pdo->prepare("UPDATE inventory_items SET qty_on_hand=? WHERE id=?")->execute([$total,$item_id]);
+      $pdo->commit();
+      header("Location: /index.php?p=items&created=1"); exit;
+    }catch(Exception $e){ $pdo->rollBack(); throw $e; }
   }
 }
 $items=$pdo->query("SELECT * FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
 ?>
-<div class="d-flex justify-content-between align-items-center mb-3"><h1 class="h3 mb-0">Items</h1><a href="/index.php?p=import" class="btn btn-outline-primary btn-sm">Import CSV</a></div>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">Items</h1>
+  <div class="d-flex gap-2">
+    <a href="/index.php?p=import" class="btn btn-outline-primary btn-sm">Import CSV</a>
+    <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#addItemModal">Add Item</button>
+  </div>
+</div>
 <?php if(isset($_GET['deleted'])): ?><div class="alert alert-success">Item deleted</div><?php endif; ?>
-<div class="row g-3"><div class="col-lg-5"><div class="card"><div class="card-body">
-<h2 class="h5">Add Item</h2>
-<form method="post"><input type="hidden" name="form" value="create_item">
-<div class="mb-2"><label class="form-label">SKU</label><input name="sku" class="form-control" required></div>
-<div class="mb-2"><label class="form-label">Name</label><input name="name" class="form-control" required></div>
-<div class="mb-2"><label class="form-label">Unit</label><input name="unit" class="form-control" placeholder="ea"></div>
-<div class="mb-2"><label class="form-label">Category</label><input name="category" class="form-control"></div>
-<div class="mb-2"><label class="form-label">Type</label><input name="item_type" class="form-control"></div>
-<div class="mb-2"><label class="form-label">Use</label><input name="item_use" class="form-control"></div>
-<div class="mb-2"><label class="form-label">Description</label><input name="description" class="form-control"></div>
-<div class="mb-2"><label class="form-label">Image URL</label><input name="image_url" class="form-control" placeholder="https://..."></div>
-<div class="mb-2"><label class="form-label">Cost (USD)</label><input name="cost_usd" type="number" step="0.01" class="form-control" value="0"></div>
-<div class="mb-2"><label class="form-label">Sage ID</label><input name="sage_id" class="form-control"></div>
-<div class="mb-2"><label class="form-label">Locations (A.1.2.3=qty per line)</label><textarea name="locations" class="form-control" rows="3" placeholder="A.1.2.3=5"></textarea></div>
-<div class="mb-2"><label class="form-label">Min Qty (optional)</label><input name="min_qty" type="number" step="0.001" class="form-control" value="0"></div>
-<button class="btn btn-primary">Save</button></form></div></div></div>
-<div class="col-lg-7"><div class="card"><div class="card-body"><h2 class="h5">All Items</h2>
+<div class="row g-3"><div class="col-lg-8 mx-auto"><div class="card"><div class="card-body"><h2 class="h5">All Items</h2>
 <div class="table-responsive"><table class="table table-sm table-striped align-middle">
 <thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Img</th><th>Name</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th>Actions</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
@@ -68,11 +67,38 @@ $items=$pdo->query("SELECT * FROM inventory_items WHERE archived=false ORDER BY 
 <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
 <td>
   <a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
-  <form method="post" class="d-inline" onsubmit="return confirm('Delete this item?');">
-    <input type="hidden" name="form" value="delete_item">
-    <input type="hidden" name="item_id" value="<?= $it['id'] ?>">
-    <button class="btn btn-sm btn-outline-danger">Delete</button>
-  </form>
 </td>
 </tr><?php endforeach; ?>
 </tbody></table></div></div></div></div></div>
+
+<div class="modal fade" id="addItemModal" tabindex="-1" aria-labelledby="addItemModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <form method="post" enctype="multipart/form-data">
+        <div class="modal-header">
+          <h5 class="modal-title" id="addItemModalLabel">Add Item</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="form" value="create_item">
+          <div class="mb-2"><label class="form-label">SKU</label><input name="sku" class="form-control" required></div>
+          <div class="mb-2"><label class="form-label">Name</label><input name="name" class="form-control" required></div>
+          <div class="mb-2"><label class="form-label">Unit</label><input name="unit" class="form-control" placeholder="ea"></div>
+          <div class="mb-2"><label class="form-label">Category</label><input name="category" class="form-control"></div>
+          <div class="mb-2"><label class="form-label">Type</label><input name="item_type" class="form-control"></div>
+          <div class="mb-2"><label class="form-label">Use</label><input name="item_use" class="form-control"></div>
+          <div class="mb-2"><label class="form-label">Description</label><input name="description" class="form-control"></div>
+          <div class="mb-2"><label class="form-label">Image</label><input type="file" name="image_file" class="form-control"></div>
+          <div class="mb-2"><label class="form-label">Cost (USD)</label><input name="cost_usd" type="number" step="0.01" class="form-control" value="0"></div>
+          <div class="mb-2"><label class="form-label">Sage ID</label><input name="sage_id" class="form-control"></div>
+          <div class="mb-2"><label class="form-label">Locations (A.1.2.3=qty per line)</label><textarea name="locations" class="form-control" rows="3" placeholder="A.1.2.3=5"></textarea></div>
+          <div class="mb-2"><label class="form-label">Min Qty (optional)</label><input name="min_qty" type="number" step="0.001" class="form-control" value="0"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button class="btn btn-primary">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/web/public/pages/report_designer.php
+++ b/web/public/pages/report_designer.php
@@ -1,0 +1,28 @@
+<?php ?>
+<h1 class="h3 mb-3">Report Designer</h1>
+<div class="row">
+  <div class="col-md-6">
+    <label for="cssInput" class="form-label">Custom CSS</label>
+    <textarea id="cssInput" class="form-control" rows="10">table.report-preview { width:100%; border-collapse:collapse; }
+table.report-preview th, table.report-preview td { border:1px solid #ccc; padding:4px; }
+table.report-preview th { background:#eee; }</textarea>
+    <button class="btn btn-primary mt-2" onclick="updatePreview()">Update Preview</button>
+  </div>
+  <div class="col-md-6">
+    <h2 class="h6">Preview</h2>
+    <div id="preview" class="border p-2">
+      <table class="report-preview">
+        <thead><tr><th>SKU</th><th>Name</th><th>Qty</th></tr></thead>
+        <tbody><tr><td>ABC123</td><td>Sample Part</td><td>10</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<style id="designerStyles"></style>
+<script>
+function updatePreview(){
+  document.getElementById('designerStyles').textContent = document.getElementById('cssInput').value;
+}
+updatePreview();
+</script>
+

--- a/web/public/pages/reports.php
+++ b/web/public/pages/reports.php
@@ -1,18 +1,101 @@
 <?php
-$pdo=db();
-$items=$pdo->query("SELECT sku,name,unit,category,item_type,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
+$pdo = db();
+$type = $_GET['type'] ?? 'full';
+$valid = ['full','low','accounting','cost_savings'];
+if (!in_array($type, $valid, true)) {
+    $type = 'full';
+}
+
+switch ($type) {
+    case 'low':
+        $title = 'Low Inventory';
+        $tableId = 'lowTable';
+        $items = $pdo->query("SELECT sku,name,min_qty,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false AND min_qty IS NOT NULL AND (qty_on_hand-qty_committed) < min_qty ORDER BY available ASC")->fetchAll();
+        break;
+    case 'accounting':
+        $title = 'Inventory for Accounting';
+        $tableId = 'acctTable';
+        $items = $pdo->query("SELECT sku,name,unit,cost_usd,qty_on_hand,(cost_usd*qty_on_hand) AS total FROM inventory_items WHERE archived=false ORDER BY sku")->fetchAll();
+        break;
+    case 'cost_savings':
+        $title = 'Cost Savings';
+        $tableId = null;
+        $items = [];
+        break;
+    default:
+        $title = 'Full Inventory';
+        $tableId = 'fullTable';
+        $items = $pdo->query("SELECT sku,name,unit,category,item_type,qty_on_hand,qty_committed,(qty_on_hand-qty_committed) AS available FROM inventory_items WHERE archived=false ORDER BY category, item_type, sku")->fetchAll();
+        break;
+}
 ?>
-<div class="d-flex justify-content-between align-items-center mb-3"><h1 class="h3 mb-0">Reports</h1>
-<div class="d-flex gap-2"><a class="btn btn-outline-primary btn-sm" href="/export_csv.php?report=snapshot">Export CSV</a>
-<button class="btn btn-primary btn-sm" onclick="exportTableToPDF('snapshotTable','Inventory Snapshot')">Export PDF</button></div></div>
-<div class="card"><div class="card-body"><h2 class="h6">Inventory Snapshot</h2>
-<div class="table-responsive"><table id="snapshotTable" class="table table-striped table-hover">
-<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th>Unit</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th class="text-end">Available</th></tr></thead>
-<tbody><?php $curCat=null; $curType=null; foreach($items as $it): ?>
-<?php if($it['category']!==$curCat){ $curCat=$it['category']; $curType=null; ?><tr class="table-secondary"><th colspan="8"><?= h($curCat) ?></th></tr><?php } ?>
-<?php if($it['item_type']!==$curType){ $curType=$it['item_type']; ?><tr class="table-light"><th colspan="8" class="ps-4"><?= h($curType) ?></th></tr><?php } ?>
-<tr>
-<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><?= h($it['sku']) ?></td><td><?= h($it['name']) ?></td><td><?= h($it['unit']) ?></td>
-<td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td><td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
-<td class="text-end"><?= number_fmt($it['available']) ?></td>
-</tr><?php endforeach; ?></tbody></table></div></div></div>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">Reports</h1>
+  <?php if($tableId): ?>
+  <div class="d-flex gap-2">
+    <a class="btn btn-outline-primary btn-sm" href="/export_csv.php?report=<?= h($type) ?>">Export CSV</a>
+    <button class="btn btn-primary btn-sm" onclick="exportTableToPDF('<?= h($tableId) ?>','<?= h($title) ?>')">Export PDF</button>
+  </div>
+  <?php endif; ?>
+</div>
+<ul class="nav nav-pills mb-3">
+  <li class="nav-item"><a class="nav-link<?= $type==='full'?' active':'' ?>" href="?p=reports&type=full">Full Inventory</a></li>
+  <li class="nav-item"><a class="nav-link<?= $type==='low'?' active':'' ?>" href="?p=reports&type=low">Low Inventory</a></li>
+  <li class="nav-item"><a class="nav-link<?= $type==='accounting'?' active':'' ?>" href="?p=reports&type=accounting">Accounting</a></li>
+  <li class="nav-item"><a class="nav-link<?= $type==='cost_savings'?' active':'' ?>" href="?p=reports&type=cost_savings">Cost Savings</a></li>
+</ul>
+
+<?php if($type==='full'): ?>
+<div class="card"><div class="card-body">
+  <h2 class="h6">Full Inventory</h2>
+  <div class="table-responsive"><table id="<?= h($tableId) ?>" class="table table-striped table-hover">
+    <thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Name</th><th>Unit</th><th class="text-end">On Hand</th><th class="text-end">Committed</th><th class="text-end">Available</th></tr></thead>
+    <tbody><?php $curCat=null; $curType=null; foreach($items as $it): ?>
+    <?php if($it['category']!==$curCat){ $curCat=$it['category']; $curType=null; ?><tr class="table-secondary"><th colspan="8"><?= h($curCat) ?></th></tr><?php } ?>
+    <?php if($it['item_type']!==$curType){ $curType=$it['item_type']; ?><tr class="table-light"><th colspan="8" class="ps-4"><?= h($curType) ?></th></tr><?php } ?>
+    <tr>
+      <td><?= h($it['category']) ?></td>
+      <td><?= h($it['item_type']) ?></td>
+      <td><?= h($it['sku']) ?></td>
+      <td><?= h($it['name']) ?></td>
+      <td><?= h($it['unit']) ?></td>
+      <td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
+      <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
+      <td class="text-end"><?= number_fmt($it['available']) ?></td>
+    </tr><?php endforeach; ?></tbody></table></div>
+</div></div>
+<?php elseif($type==='low'): ?>
+<div class="card"><div class="card-body">
+  <h2 class="h6">Low Inventory</h2>
+  <div class="table-responsive"><table id="<?= h($tableId) ?>" class="table table-striped table-hover">
+    <thead><tr><th>SKU</th><th>Name</th><th class="text-end">Min Qty</th><th class="text-end">Available</th></tr></thead>
+    <tbody><?php foreach($items as $it): ?>
+    <tr>
+      <td><?= h($it['sku']) ?></td>
+      <td><?= h($it['name']) ?></td>
+      <td class="text-end"><?= number_fmt($it['min_qty']) ?></td>
+      <td class="text-end"><?= number_fmt($it['available']) ?></td>
+    </tr><?php endforeach; ?></tbody></table></div>
+</div></div>
+<?php elseif($type==='accounting'): ?>
+<div class="card"><div class="card-body">
+  <h2 class="h6">Inventory for Accounting</h2>
+  <div class="table-responsive"><table id="<?= h($tableId) ?>" class="table table-striped table-hover">
+    <thead><tr><th>SKU</th><th>Name</th><th>Unit</th><th class="text-end">Cost</th><th class="text-end">On Hand</th><th class="text-end">Value</th></tr></thead>
+    <tbody><?php foreach($items as $it): ?>
+    <tr>
+      <td><?= h($it['sku']) ?></td>
+      <td><?= h($it['name']) ?></td>
+      <td><?= h($it['unit']) ?></td>
+      <td class="text-end">$<?= number_fmt($it['cost_usd']) ?></td>
+      <td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
+      <td class="text-end">$<?= number_fmt($it['total']) ?></td>
+    </tr><?php endforeach; ?></tbody></table></div>
+</div></div>
+<?php else: ?>
+<div class="card"><div class="card-body">
+  <h2 class="h6">Cost Savings</h2>
+  <p class="mb-0 text-secondary">This report is under development.</p>
+</div></div>
+<?php endif; ?>
+

--- a/web/public/pages/settings.php
+++ b/web/public/pages/settings.php
@@ -3,14 +3,17 @@ $pdo=db();
 $saved=false;
 $freq=$pdo->query("SELECT value FROM settings WHERE key='cycle_count_frequency'")->fetchColumn();
 $display=$pdo->query("SELECT value FROM settings WHERE key='dashboard_display'")->fetchColumn() ?: 'grouped';
+$variant=$pdo->query("SELECT value FROM settings WHERE key='variant_view'")->fetchColumn() ?: 'individual';
 $modulesVal=$pdo->query("SELECT value FROM settings WHERE key='dashboard_modules'")->fetchColumn();
 $modules=$modulesVal?explode(',', $modulesVal):['parts_list'];
 if($_SERVER['REQUEST_METHOD']==='POST'){
   $pdo->prepare("INSERT INTO settings (key,value) VALUES ('cycle_count_frequency',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([$_POST['frequency']]);
   $pdo->prepare("INSERT INTO settings (key,value) VALUES ('dashboard_display',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([$_POST['dashboard_display']]);
+  $pdo->prepare("INSERT INTO settings (key,value) VALUES ('variant_view',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([$_POST['variant_view']]);
   $pdo->prepare("INSERT INTO settings (key,value) VALUES ('dashboard_modules',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([implode(',', $_POST['modules'] ?? [])]);
   $freq=$_POST['frequency'];
   $display=$_POST['dashboard_display'];
+  $variant=$_POST['variant_view'];
   $modules=$_POST['modules'] ?? [];
   $saved=true;
 }
@@ -33,6 +36,12 @@ $availableModules=[
 <select name="dashboard_display" class="form-select">
 <option value="grouped" <?= $display==='grouped'?'selected':'' ?>>Grouped</option>
 <option value="table" <?= $display==='table'?'selected':'' ?>>Table</option>
+</select></div>
+
+<div class="mb-3"><label class="form-label">Variant Display</label>
+<select name="variant_view" class="form-select">
+<option value="individual" <?= $variant==='individual'?'selected':'' ?>>Individual SKUs</option>
+<option value="grouped" <?= $variant==='grouped'?'selected':'' ?>>Group by Base SKU</option>
 </select></div>
 
 <div class="mb-3"><label class="form-label">Dashboard Modules</label>

--- a/web/public/pages/settings.php
+++ b/web/public/pages/settings.php
@@ -2,12 +2,24 @@
 $pdo=db();
 $saved=false;
 $freq=$pdo->query("SELECT value FROM settings WHERE key='cycle_count_frequency'")->fetchColumn();
+$display=$pdo->query("SELECT value FROM settings WHERE key='dashboard_display'")->fetchColumn() ?: 'grouped';
+$modulesVal=$pdo->query("SELECT value FROM settings WHERE key='dashboard_modules'")->fetchColumn();
+$modules=$modulesVal?explode(',', $modulesVal):['parts_list'];
 if($_SERVER['REQUEST_METHOD']==='POST'){
   $pdo->prepare("INSERT INTO settings (key,value) VALUES ('cycle_count_frequency',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([$_POST['frequency']]);
+  $pdo->prepare("INSERT INTO settings (key,value) VALUES ('dashboard_display',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([$_POST['dashboard_display']]);
+  $pdo->prepare("INSERT INTO settings (key,value) VALUES ('dashboard_modules',?) ON CONFLICT (key) DO UPDATE SET value=excluded.value")->execute([implode(',', $_POST['modules'] ?? [])]);
   $freq=$_POST['frequency'];
+  $display=$_POST['dashboard_display'];
+  $modules=$_POST['modules'] ?? [];
   $saved=true;
 }
 $options=['weekly','bi-weekly','monthly','quarterly','semi-annual','annual'];
+$availableModules=[
+  'parts_list'=>'Parts List',
+  'low_stock'=>'Low Stock Parts',
+  'counts_due'=>'Counts Due'
+];
 ?>
 <h1 class="h3 mb-3">Settings</h1>
 <?php if($saved): ?><div class="alert alert-success">Saved</div><?php endif; ?>
@@ -16,5 +28,21 @@ $options=['weekly','bi-weekly','monthly','quarterly','semi-annual','annual'];
 <select name="frequency" class="form-select" required>
 <?php foreach($options as $o): ?><option value="<?= $o ?>" <?= $freq===$o?'selected':'' ?>><?= ucfirst($o) ?></option><?php endforeach; ?>
 </select></div>
+
+<div class="mb-3"><label class="form-label">Dashboard Parts Display</label>
+<select name="dashboard_display" class="form-select">
+<option value="grouped" <?= $display==='grouped'?'selected':'' ?>>Grouped</option>
+<option value="table" <?= $display==='table'?'selected':'' ?>>Table</option>
+</select></div>
+
+<div class="mb-3"><label class="form-label">Dashboard Modules</label>
+<?php foreach($availableModules as $key=>$label): ?>
+<div class="form-check">
+  <input class="form-check-input" type="checkbox" name="modules[]" value="<?= $key ?>" id="mod-<?= $key ?>" <?= in_array($key,$modules)?'checked':'' ?>>
+  <label class="form-check-label" for="mod-<?= $key ?>"><?= $label ?></label>
+</div>
+<?php endforeach; ?>
+</div>
+
 <button class="btn btn-primary">Save</button>
 </form>

--- a/web/public/partials/header.php
+++ b/web/public/partials/header.php
@@ -13,6 +13,7 @@
 <li class="nav-item"><a class="nav-link" href="/index.php?p=jobs">Jobs</a></li>
 <li class="nav-item"><a class="nav-link" href="/index.php?p=cycle_counts">Cycle Counts</a></li>
 <li class="nav-item"><a class="nav-link" href="/index.php?p=reports">Reports</a></li>
+<li class="nav-item"><a class="nav-link" href="/index.php?p=report_designer">Report Designer</a></li>
 <li class="nav-item"><a class="nav-link" href="/index.php?p=settings">Settings</a></li>
 </ul>
 <div class="form-check form-switch"><input class="form-check-input" type="checkbox" role="switch" id="themeSwitch"><label class="form-check-label" for="themeSwitch">Light</label></div>


### PR DESCRIPTION
## Summary
- Center the items list and move deletion to item detail page
- Add modal-based item creation with image uploads stored under `web/public/uploads`
- Allow updating item images, converting uploads to JPG to keep DB lean

## Testing
- `php -l web/public/pages/items.php`
- `php -l web/public/pages/item.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3b1dc4e4c8329b29f82b012053c26