### PR TITLE
Fix editing for grouped base parts

### DIFF
--- a/web/public/modules/parts_list.php
+++ b/web/public/modules/parts_list.php
@@ -22,7 +22,7 @@ if($variantView==='grouped'){
 <td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
 <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
 <td class="text-end"><?= number_fmt($it['available']) ?></td>
-<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
+<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&id=<?= $it['id'] ?>">Edit</a>
 <a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
 <a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
 </tr>
@@ -46,7 +46,7 @@ if($variantView==='grouped'){
 <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
 <td class="text-end"><?= number_fmt($it['available']) ?></td>
 <td><?php if($short_onhand): ?><span class="badge badge-short">NEG On Hand</span><?php endif; ?><?php if($short_avail): ?><span class="badge text-bg-danger">Over-committed</span><?php endif; ?></td>
-<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
+<td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&id=<?= $it['id'] ?>">Edit</a>
 <a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
 <a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
 </tr>

--- a/web/public/pages/item.php
+++ b/web/public/pages/item.php
@@ -1,9 +1,18 @@
 <?php
 $pdo=db();
-$sku=$_GET['sku']??'';
-$stmt=$pdo->prepare("SELECT * FROM inventory_items WHERE sku=?");
-$stmt->execute([$sku]);
-$item=$stmt->fetch();
+$id=$_GET['id']??($_GET['item_id']??null);
+if($id){
+  $stmt=$pdo->prepare("SELECT * FROM inventory_items WHERE id=?");
+  $stmt->execute([$id]);
+  $item=$stmt->fetch();
+  $sku=$item['sku']??'';
+}else{
+  $sku=$_GET['sku']??'';
+  $stmt=$pdo->prepare("SELECT * FROM inventory_items WHERE sku=?");
+  $stmt->execute([$sku]);
+  $item=$stmt->fetch();
+  $id=$item['id']??null;
+}
 if(!$item){ echo '<div class="alert alert-danger">Item not found</div>'; return; }
 if($_SERVER['REQUEST_METHOD']==='POST'){
   $form=$_POST['form']??'';
@@ -51,7 +60,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
       }
       $pdo->prepare("UPDATE inventory_items SET qty_on_hand=? WHERE id=?")->execute([$total,$item['id']]);
       $pdo->commit();
-      header("Location: /index.php?p=item&sku=".urlencode($sku)."&updated=1"); exit;
+      header("Location: /index.php?p=item&id=".$item['id']."&updated=1"); exit;
     }catch(Exception $e){ $pdo->rollBack(); throw $e; }
   }elseif($form==='delete_item'){
     $pdo->prepare("DELETE FROM inventory_items WHERE id=?")->execute([$item['id']]);

--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -68,7 +68,7 @@ if($variantView==='grouped'){
     'qty_committed'=>'SUM(qty_committed)'
   ];
   $sortExpr=$sortMap[$sort];
-  $items=$pdo->query("SELECT COALESCE(parent_sku,sku) AS sku, MIN(name) AS name, MIN(unit) AS unit, MIN(category) AS category, MIN(item_type) AS item_type, MIN(image_url) AS image_url, SUM(qty_on_hand) AS qty_on_hand, SUM(qty_committed) AS qty_committed FROM inventory_items WHERE archived=false GROUP BY COALESCE(parent_sku,sku) ORDER BY $sortExpr $dir, sku ASC")->fetchAll();
+  $items=$pdo->query("SELECT MIN(id) AS id, COALESCE(parent_sku,sku) AS sku, MIN(name) AS name, MIN(unit) AS unit, MIN(category) AS category, MIN(item_type) AS item_type, MIN(image_url) AS image_url, SUM(qty_on_hand) AS qty_on_hand, SUM(qty_committed) AS qty_committed FROM inventory_items WHERE archived=false GROUP BY COALESCE(parent_sku,sku) ORDER BY $sortExpr $dir, sku ASC")->fetchAll();
 }else{
   $items=$pdo->query("SELECT * FROM inventory_items WHERE archived=false ORDER BY $sort $dir, sku ASC")->fetchAll();
 }
@@ -85,13 +85,13 @@ if($variantView==='grouped'){
 <div class="table-responsive"><table class="table table-sm table-striped align-middle">
 <thead><tr><th><?= sort_link('category','Category',$sort,$dir) ?></th><th><?= sort_link('item_type','Type',$sort,$dir) ?></th><th><?= sort_link('sku','SKU',$sort,$dir) ?></th><th>Img</th><th><?= sort_link('name','Name',$sort,$dir) ?></th><th class="text-end"><?= sort_link('qty_on_hand','On Hand',$sort,$dir) ?></th><th class="text-end"><?= sort_link('qty_committed','Committed',$sort,$dir) ?></th><th>Actions</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
-<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><a href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>"><?= h($it['sku']) ?></a></td>
+<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><a href="/index.php?p=item&id=<?= $it['id'] ?>"><?= h($it['sku']) ?></a></td>
 <td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;"><?php endif; ?></td>
 <td><?= h($it['name']) ?></td>
 <td class="text-end"><?= number_fmt($it['qty_on_hand']) ?></td>
 <td class="text-end"><?= number_fmt($it['qty_committed']) ?></td>
 <td>
-  <a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&sku=<?= urlencode($it['sku']) ?>">Edit</a>
+  <a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&id=<?= $it['id'] ?>">Edit</a>
 </td>
 </tr><?php endforeach; ?>
 </tbody></table></div></div></div></div></div>


### PR DESCRIPTION
## Summary
- Link parts list and item catalog entries to the item editor using ID instead of SKU
- Accept `id` in item editor so grouped base parts open correctly

## Testing
- `php -l web/public/modules/parts_list.php`
- `php -l web/public/pages/items.php`
- `php -l web/public/pages/item.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3bda2aa188329817ad12047126509