### PR TITLE
Improve cycle count worksheet PDF export

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -16,10 +16,18 @@
     const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'letter'});
     const table = document.getElementById(tableId);
     if(!table) return alert('Table not found');
-    let y = 40;
+
+    const margin = 40;
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    const usableWidth = pageWidth - margin*2;
+    const rowHeight = 20;
+
     doc.setFontSize(16);
-    doc.text(title || 'Inventory Report', 40, y);
-    y += 20;
+    let y = margin;
+    doc.text(title || 'Inventory Report', margin, y);
+    y += 30;
+
     const headers = [];
     table.querySelectorAll('thead th').forEach(th => headers.push(th.innerText.trim()));
     const rows = [];
@@ -28,21 +36,34 @@
       tr.querySelectorAll('td').forEach(td => row.push(td.innerText.trim()));
       rows.push(row);
     });
-    const colWidth = 720 / headers.length;
-    doc.setFont('helvetica','bold');
-    headers.forEach((h,i)=> doc.text(h, 40 + i*colWidth, y));
-    doc.line(40, y+2, 40 + headers.length*colWidth, y+2);
-    y += 14;
-    doc.setFont('helvetica','normal');
+    const colWidth = usableWidth / headers.length;
+
+    function drawHeader(){
+      doc.setFontSize(12);
+      doc.setFont('helvetica','bold');
+      headers.forEach((h,i)=>{
+        doc.rect(margin + i*colWidth, y, colWidth, rowHeight);
+        doc.text(h, margin + i*colWidth + 2, y + 14);
+      });
+      doc.setFont('helvetica','normal');
+      y += rowHeight;
+    }
+
+    drawHeader();
+
     rows.forEach(r => {
-      r.forEach((cell,i)=> doc.text(String(cell), 40 + i*colWidth, y));
-      doc.line(40, y+2, 40 + headers.length*colWidth, y+2);
-      y += 14;
-      if(y > 540){
+      if(y + rowHeight > pageHeight - margin){
         doc.addPage();
-        y = 40;
+        y = margin;
+        drawHeader();
       }
+      r.forEach((cell,i)=>{
+        doc.rect(margin + i*colWidth, y, colWidth, rowHeight);
+        doc.text(String(cell), margin + i*colWidth + 2, y + 14);
+      });
+      y += rowHeight;
     });
+
     doc.save((title || 'report') + '.pdf');
   };
 })();

--- a/web/public/pages/cycle_count_sheet.php
+++ b/web/public/pages/cycle_count_sheet.php
@@ -3,7 +3,10 @@ $pdo=db();
 $items=$pdo->query("SELECT i.category,i.item_type,i.sku,i.name,i.image_url,l.location FROM inventory_items i LEFT JOIN item_locations l ON l.item_id=i.id WHERE i.archived=false ORDER BY i.category,i.item_type,i.sku,l.location")->fetchAll();
 ?>
 <h1 class="h3 mb-3">Cycle Count Worksheet</h1>
-<div class="table-responsive"><table class="table table-bordered">
+<div class="mb-3">
+  <button class="btn btn-outline-secondary btn-sm" onclick="exportTableToPDF('cycle-count-table','Cycle Count Worksheet')">Export PDF</button>
+</div>
+<div class="table-responsive"><table id="cycle-count-table" class="table table-bordered">
 <thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Img</th><th>Name</th><th>Location</th><th>Count</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
 <td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><?= h($it['sku']) ?></td><td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;"><?php endif; ?></td><td><?= h($it['name']) ?></td><td><?= h($it['location']) ?></td><td></td>


### PR DESCRIPTION
## Summary
- Add PDF export button to cycle count worksheet
- Render PDF with 12pt font and table cell borders in landscape orientation

## Testing
- `php -l web/public/pages/cycle_count_sheet.php`
- `node --check web/public/assets/app.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b71a5901348329a4b06a92a885e6db