### PR TITLE
Refine cycle count sheet PDF format

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -21,12 +21,13 @@
     const pageWidth = doc.internal.pageSize.getWidth();
     const pageHeight = doc.internal.pageSize.getHeight();
     const usableWidth = pageWidth - margin*2;
-    const rowHeight = 20;
+    const rowHeight = 12;
 
     doc.setFontSize(16);
     let y = margin;
     doc.text(title || 'Inventory Report', margin, y);
-    y += 30;
+    y += 24;
+    doc.setFontSize(10);
 
     const headers = [];
     table.querySelectorAll('thead th').forEach(th => headers.push(th.innerText.trim()));
@@ -39,11 +40,10 @@
     const colWidth = usableWidth / headers.length;
 
     function drawHeader(){
-      doc.setFontSize(12);
       doc.setFont('helvetica','bold');
       headers.forEach((h,i)=>{
         doc.rect(margin + i*colWidth, y, colWidth, rowHeight);
-        doc.text(h, margin + i*colWidth + 2, y + 14);
+        doc.text(h, margin + i*colWidth + 2, y + rowHeight - 3);
       });
       doc.setFont('helvetica','normal');
       y += rowHeight;
@@ -59,7 +59,7 @@
       }
       r.forEach((cell,i)=>{
         doc.rect(margin + i*colWidth, y, colWidth, rowHeight);
-        doc.text(String(cell), margin + i*colWidth + 2, y + 14);
+        doc.text(String(cell), margin + i*colWidth + 2, y + rowHeight - 3);
       });
       y += rowHeight;
     });

--- a/web/public/pages/cycle_count_sheet.php
+++ b/web/public/pages/cycle_count_sheet.php
@@ -1,13 +1,13 @@
 <?php
 $pdo=db();
-$items=$pdo->query("SELECT i.category,i.item_type,i.sku,i.name,i.image_url,l.location FROM inventory_items i LEFT JOIN item_locations l ON l.item_id=i.id WHERE i.archived=false ORDER BY i.category,i.item_type,i.sku,l.location")->fetchAll();
+$items=$pdo->query("SELECT i.sku,i.name,l.location FROM inventory_items i LEFT JOIN item_locations l ON l.item_id=i.id WHERE i.archived=false AND i.sku NOT IN (SELECT parent_sku FROM inventory_items WHERE parent_sku IS NOT NULL) ORDER BY i.sku,l.location")->fetchAll();
 ?>
 <h1 class="h3 mb-3">Cycle Count Worksheet</h1>
 <div class="mb-3">
   <button class="btn btn-outline-secondary btn-sm" onclick="exportTableToPDF('cycle-count-table','Cycle Count Worksheet')">Export PDF</button>
 </div>
 <div class="table-responsive"><table id="cycle-count-table" class="table table-bordered">
-<thead><tr><th>Category</th><th>Type</th><th>SKU</th><th>Img</th><th>Name</th><th>Location</th><th>Count</th></tr></thead>
+<thead><tr><th>SKU</th><th>Name</th><th>Location</th><th>Count</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
-<td><?= h($it['category']) ?></td><td><?= h($it['item_type']) ?></td><td><?= h($it['sku']) ?></td><td><?php if($it['image_url']): ?><img src="<?= h($it['image_url']) ?>" alt="" style="width:32px;height:32px;object-fit:cover;"><?php endif; ?></td><td><?= h($it['name']) ?></td><td><?= h($it['location']) ?></td><td></td>
+<td><?= h($it['sku']) ?></td><td><?= h($it['name']) ?></td><td><?= h($it['location']) ?></td><td></td>
 </tr><?php endforeach; ?></tbody></table></div>


### PR DESCRIPTION
## Summary
- Render count sheet PDF using 10pt font with 12pt rows for spacing
- Exclude category, type, image columns and base SKUs on cycle count sheet
- Align PDF columns for cleaner layout

## Testing
- `node --check web/public/assets/app.js`
- `php -l web/public/pages/cycle_count_sheet.php`


------
https://chatgpt.com/codex/tasks/task_e_68b71bf4f6cc8329bd81ce6457a57e1d