### PR TITLE
Install zip extension and guard import

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:8.2-apache
-RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev git zip unzip  && docker-php-ext-install pdo pdo_pgsql  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev git zip unzip libzip-dev && docker-php-ext-install pdo pdo_pgsql zip && rm -rf /var/lib/apt/lists/*
 RUN a2enmod rewrite
 RUN { echo 'date.timezone=UTC'; echo 'upload_max_filesize=16M'; echo 'post_max_size=16M'; } > /usr/local/etc/php/conf.d/app.ini
 WORKDIR /var/www/html

--- a/web/public/modules/job_material_import.php
+++ b/web/public/modules/job_material_import.php
@@ -8,6 +8,9 @@ function parse_job_materials_xlsx(string $path): array {
         'Stock Length (2)',
         'Stock Length (3)'
     ];
+    if (!class_exists('ZipArchive')) {
+        throw new Exception('ZipArchive extension not installed');
+    }
     $zip = new ZipArchive();
     if($zip->open($path)!==true){
         throw new Exception('Unable to open spreadsheet');


### PR DESCRIPTION
## Summary
- Install libzip and compile zip extension in PHP Docker image to enable ZipArchive
- Guard job material import against missing ZipArchive extension

## Testing
- `php -l web/public/modules/job_material_import.php`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b79b5fd5208329b135894b0c72ba8c