### PR TITLE
Install zip extension and guard import

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:8.2-apache
-RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev git zip unzip  && docker-php-ext-install pdo pdo_pgsql  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev git zip unzip libzip-dev && docker-php-ext-install pdo pdo_pgsql zip && rm -rf /var/lib/apt/lists/*
 RUN a2enmod rewrite
 RUN { echo 'date.timezone=UTC'; echo 'upload_max_filesize=16M'; echo 'post_max_size=16M'; } > /usr/local/etc/php/conf.d/app.ini
 WORKDIR /var/www/html

--- a/web/public/modules/job_material_import.php
+++ b/web/public/modules/job_material_import.php
@@ -8,6 +8,9 @@ function parse_job_materials_xlsx(string $path): array {
         'Stock Length (2)',
         'Stock Length (3)'
     ];
+    if (!class_exists('ZipArchive')) {
+        throw new Exception('ZipArchive extension not installed');
+    }
     $zip = new ZipArchive();
     if($zip->open($path)!==true){
         throw new Exception('Unable to open spreadsheet');
@@ -54,7 +57,7 @@ function parse_job_materials_xlsx(string $path): array {
         if(!$sx || !isset($sx->sheetData)) continue;
         foreach($sx->sheetData->row as $row){
             $r=(int)$row['r'];
-            if($r<11 || $r>46) continue;
+            if($r<=10) continue; // skip header rows
             $vals=['A'=>null,'B'=>null,'C'=>null];
             foreach($row->c as $c){
                 $ref=(string)$c['r'];

--- a/web/public/pages/jobs.php
+++ b/web/public/pages/jobs.php
@@ -31,12 +31,15 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='import_mat
     require_once __DIR__.'/../modules/job_material_import.php';
     try{
       $rows=parse_job_materials_xlsx($_FILES['xlsx']['tmp_name']);
+      $imported=0;
+      $report=[];
       foreach($rows as $r){
         $qty=max(0,(float)$r[0]);
         $base=trim($r[1] ?? '');
         $finish=strtoupper(trim($r[2] ?? ''));
         if($qty<=0 || $base==='') continue;
         $sku=$base.($finish!==''?('-'.$finish):'');
+        $report[]="$qty x $sku";
         $pdo->beginTransaction();
         $cur=$pdo->prepare("SELECT id, qty_on_hand, qty_committed FROM inventory_items WHERE sku=? FOR UPDATE");
         $cur->execute([$sku]);
@@ -52,6 +55,15 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='import_mat
         $note=$over_commit>0?('Commit to job (OVER by '.$over_commit.')'):'Commit to job';
         $pdo->prepare("INSERT INTO inventory_txns (item_id,txn_type,qty_delta,ref_table,ref_id,note) VALUES (?,?,?,?,?,?)")->execute([$item_id,'job_release',0,'jobs',$job_id,$note]);
         $pdo->commit();
+        $imported++;
+      }
+      if(PHP_SAPI==='cli'){
+        foreach($report as $line){
+          fwrite(STDOUT,$line.PHP_EOL);
+        }
+      }
+      if($imported===0){
+        throw new Exception('No materials were imported');
       }
       header("Location: /index.php?p=jobs&view=".$job_id."&imp=1"); exit;
     }catch(Exception $e){ $err=$e->getMessage(); }


### PR DESCRIPTION
## Summary
- Install libzip and compile zip extension in PHP Docker image to enable ZipArchive
- Guard job material import against missing ZipArchive extension
- Parse all spreadsheet rows and report when no materials were imported
- Log identified parts to console when importing materials via CLI
- Skip the first 10 spreadsheet rows so data starts at row 11

## Testing
- `php -l web/public/modules/job_material_import.php`
- `php -l web/public/pages/jobs.php`
- `docker --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b79b5fd5208329b135894b0c72ba8c