### PR TITLE
Fix job material import and allow XLSM uploads

### DIFF
--- a/web/public/modules/job_material_import.php
+++ b/web/public/modules/job_material_import.php
@@ -193,3 +193,19 @@ function parse_job_materials_xlsx_refined(
     $zip->close();
     return $rows;
 }
+/**
+ * Wrapper for backwards compatibility.
+ *
+ * @deprecated Use parse_job_materials_xlsx_refined() instead.
+ */
+function parse_job_materials_xlsx(
+    string $path,
+    array $requiredSheets = [
+        'Accessories','Accessories (2)','Accessories (3)',
+        'Stock Lengths','Stock Lengths (2)','Stock Lengths (3)'
+    ],
+    int $skipHeaderRows = 10,
+    ?callable $logger = null
+): array {
+    return parse_job_materials_xlsx_refined($path, $requiredSheets, $skipHeaderRows, $logger);
+}

--- a/web/public/pages/jobs.php
+++ b/web/public/pages/jobs.php
@@ -228,7 +228,7 @@ if(isset($_GET['view'])){
         <form method="post" enctype="multipart/form-data" class="row gy-2 gx-2 align-items-end mt-3">
           <input type="hidden" name="form" value="import_materials">
           <input type="hidden" name="job_id" value="<?= $view_job['id'] ?>">
-          <div class="col-md-6"><label class="form-label">Import Spreadsheet</label><input type="file" name="xlsx" accept=".xlsx" class="form-control" required></div>
+          <div class="col-md-6"><label class="form-label">Import Spreadsheet</label><input type="file" name="xlsx" accept=".xlsx,.xlsm" class="form-control" required></div>
           <div class="col-md-3"><label class="form-label">&nbsp;</label><button class="btn btn-outline-primary w-100">Import</button></div>
         </form>
         <div class="form-text mt-1">Over-committing is allowed; shortages will be highlighted on the dashboard.</div>


### PR DESCRIPTION
## Summary
- Add backwards-compatible wrapper for refactored job material import parser
- Permit `.xlsm` spreadsheets to be uploaded for job imports

## Testing
- `php -l web/public/modules/job_material_import.php`
- `php -l web/public/pages/jobs.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7aa418c288329b80ef180e63701a5