### PR TITLE
feat: track job work orders and consumption

### DIFF
--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -22,8 +22,24 @@ CREATE TABLE IF NOT EXISTS inventory_items (
 );
 CREATE TABLE IF NOT EXISTS jobs (id SERIAL PRIMARY KEY, job_number VARCHAR(64) UNIQUE NOT NULL, name TEXT, status VARCHAR(16) NOT NULL DEFAULT 'bid' CHECK (status IN ('bid','active','complete','cancelled')), archived BOOLEAN NOT NULL DEFAULT FALSE, date_released DATE, date_completed DATE, notes TEXT, created_at TIMESTAMP DEFAULT now(), updated_at TIMESTAMP DEFAULT now());
 CREATE TABLE IF NOT EXISTS job_materials (id SERIAL PRIMARY KEY, job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE, item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE CASCADE, qty_committed NUMERIC(12,3) NOT NULL, qty_used NUMERIC(12,3) NOT NULL DEFAULT 0, created_at TIMESTAMP DEFAULT now(), updated_at TIMESTAMP DEFAULT now(), UNIQUE(job_id, item_id));
+CREATE TABLE IF NOT EXISTS work_orders (
+    id SERIAL PRIMARY KEY,
+    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    wo_number TEXT NOT NULL,
+    date_released DATE,
+    created_at TIMESTAMP DEFAULT now(),
+    UNIQUE(job_id, wo_number)
+);
+CREATE TABLE IF NOT EXISTS job_consumptions (
+    id SERIAL PRIMARY KEY,
+    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE CASCADE,
+    work_order_id INTEGER REFERENCES work_orders(id) ON DELETE SET NULL,
+    qty_used NUMERIC(12,3) NOT NULL,
+    date_used TIMESTAMP DEFAULT now()
+);
 CREATE TABLE IF NOT EXISTS cycle_counts (id SERIAL PRIMARY KEY, item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE CASCADE, counted_qty NUMERIC(12,3) NOT NULL, count_date DATE NOT NULL DEFAULT CURRENT_DATE, note TEXT, created_at TIMESTAMP DEFAULT now());
-CREATE TABLE IF NOT EXISTS inventory_txns (id SERIAL PRIMARY KEY, item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE CASCADE, txn_type VARCHAR(32) NOT NULL CHECK (txn_type IN ('cycle_count','job_release','job_complete','adjustment','return')), qty_delta NUMERIC(12,3) NOT NULL, ref_table VARCHAR(64), ref_id INTEGER, note TEXT, created_at TIMESTAMP DEFAULT now());
+CREATE TABLE IF NOT EXISTS inventory_txns (id SERIAL PRIMARY KEY, item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE CASCADE, txn_type VARCHAR(32) NOT NULL CHECK (txn_type IN ('cycle_count','job_release','job_consume','job_complete','adjustment','return')), qty_delta NUMERIC(12,3) NOT NULL, ref_table VARCHAR(64), ref_id INTEGER, note TEXT, created_at TIMESTAMP DEFAULT now());
 CREATE TABLE IF NOT EXISTS item_locations (
     id SERIAL PRIMARY KEY,
     item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- add work order and job consumption tables
- allow partial material usage and logging per work order
- display work orders and consumption log in job page

## Testing
- `php -l web/public/pages/jobs.php`


------
https://chatgpt.com/codex/tasks/task_e_68b86aea951c832988cce54a935e9421