### PR TITLE
Improve job management and item listing

### DIFF
--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -82,7 +82,7 @@ if($variantView==='grouped'){
   </div>
 </div>
 <?php if(isset($_GET['deleted'])): ?><div class="alert alert-success">Item deleted</div><?php endif; ?>
-<div class="row g-3"><div class="col-lg-8 mx-auto"><div class="card"><div class="card-body"><h2 class="h5">All Items</h2>
+<div class="card"><div class="card-body"><h2 class="h5">All Items</h2>
 <div class="table-responsive"><table class="table table-sm table-striped align-middle">
 <thead><tr><th><?= sort_link('category','Category',$sort,$dir) ?></th><th><?= sort_link('item_type','Type',$sort,$dir) ?></th><th><?= sort_link('sku','SKU',$sort,$dir) ?></th><th>Img</th><th><?= sort_link('name','Name',$sort,$dir) ?></th><th class="text-end"><?= sort_link('qty_on_hand','On Hand',$sort,$dir) ?></th><th class="text-end"><?= sort_link('qty_committed','Committed',$sort,$dir) ?></th><th>Actions</th></tr></thead>
 <tbody><?php foreach($items as $it): ?><tr>
@@ -95,7 +95,7 @@ if($variantView==='grouped'){
   <a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&id=<?= $it['id'] ?>">Edit</a>
 </td>
 </tr><?php endforeach; ?>
-</tbody></table></div></div></div></div></div>
+</tbody></table></div></div></div>
 
 <div class="modal fade" id="addItemModal" tabindex="-1" aria-labelledby="addItemModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg">

--- a/web/public/pages/work_order.php
+++ b/web/public/pages/work_order.php
@@ -73,7 +73,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
   }
 }
 
-$items=$pdo->query("SELECT id, sku, name FROM inventory_items WHERE archived=false ORDER BY sku")->fetchAll();
+$items=$pdo->query("SELECT id, sku, name FROM inventory_items WHERE archived=false AND sku NOT IN (SELECT parent_sku FROM inventory_items WHERE parent_sku IS NOT NULL) ORDER BY sku")->fetchAll();
 $m=$pdo->prepare("SELECT jm.id as jm_id, i.sku, i.name, i.unit, jm.qty_committed, jm.qty_used, i.id as item_id FROM job_materials jm JOIN inventory_items i ON i.id=jm.item_id WHERE jm.job_id=? ORDER BY i.sku");
 $m->execute([$job_id]); $materials=$m->fetchAll();
 $c=$pdo->prepare("SELECT jc.qty_used, jc.date_used, i.sku, i.name FROM job_consumptions jc JOIN inventory_items i ON i.id=jc.item_id WHERE jc.work_order_id=? ORDER BY jc.date_used");


### PR DESCRIPTION
## Summary
- Expand items page table to full width for consistency
- Filter out base SKUs from job and work order item selection
- Display work orders in a table with edit links and add job undo/delete controls

## Testing
- `php -l web/public/pages/items.php`
- `php -l web/public/pages/jobs.php`
- `php -l web/public/pages/work_order.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba0c1f20a483299156a16599b57c7e