### PR TITLE
Preselect item in job commit form

### DIFF
--- a/web/public/modules/parts_list.php
+++ b/web/public/modules/parts_list.php
@@ -24,7 +24,7 @@ if($variantView==='grouped'){
 <td class="text-end"><?= number_fmt($it['available']) ?></td>
 <td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&id=<?= $it['id'] ?>">Edit</a>
 <a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
-<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
+<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&item_id=<?= $it['id'] ?>">Commit</a></td>
 </tr>
 <?php endforeach; ?>
 </tbody></table></div>
@@ -48,7 +48,7 @@ if($variantView==='grouped'){
 <td><?php if($short_onhand): ?><span class="badge badge-short">NEG On Hand</span><?php endif; ?><?php if($short_avail): ?><span class="badge text-bg-danger">Over-committed</span><?php endif; ?></td>
 <td><a class="btn btn-sm btn-outline-secondary" href="/index.php?p=item&id=<?= $it['id'] ?>">Edit</a>
 <a class="btn btn-sm btn-outline-primary" href="/index.php?p=cycle_counts&item_id=<?= $it['id'] ?>">Count</a>
-<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&action=add_material&item_id=<?= $it['id'] ?>">Commit</a></td>
+<a class="btn btn-sm btn-outline-success" href="/index.php?p=jobs&item_id=<?= $it['id'] ?>">Commit</a></td>
 </tr>
 <?php endforeach; ?>
 </tbody></table></div>

--- a/web/public/pages/jobs.php
+++ b/web/public/pages/jobs.php
@@ -139,6 +139,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && ( $_POST['form'] ?? '' )==='complete_j
   }catch(Exception $e){ $pdo->rollBack(); $err=$e->getMessage(); }
 }
 $items=$pdo->query("SELECT id, sku, name FROM inventory_items WHERE archived=false ORDER BY sku")->fetchAll();
+$selected_item_id=isset($_GET['item_id'])?(int)$_GET['item_id']:0;
 $show_archived=isset($_GET['show_archived']);
 $job_stmt=$pdo->prepare("SELECT * FROM jobs".($show_archived?"":" WHERE archived=false")." ORDER BY created_at DESC LIMIT 50");
 $job_stmt->execute();
@@ -228,7 +229,7 @@ if(isset($_GET['view'])){
           <div class="col-md-6"><label class="form-label">Item</label>
             <select name="item_id" class="form-select" required>
               <option value="">Select item…</option>
-              <?php foreach($items as $it): ?><option value="<?= $it['id'] ?>"><?= h($it['sku']) ?> — <?= h($it['name']) ?></option><?php endforeach; ?>
+              <?php foreach($items as $it): ?><option value="<?= $it['id'] ?>" <?= $selected_item_id===$it['id']?'selected':'' ?>><?= h($it['sku']) ?> — <?= h($it['name']) ?></option><?php endforeach; ?>
             </select>
           </div>
           <div class="col-md-3"><label class="form-label">Qty</label><input type="number" step="0.001" name="qty_committed" class="form-control" required></div>


### PR DESCRIPTION
## Summary
- Remove obsolete `action=add_material` parameter in parts list commit links
- Preselect item in job commit form using `item_id` query param

## Testing
- `php -l web/public/modules/parts_list.php`
- `php -l web/public/pages/jobs.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb83921a4083299dac777bcfe3273a