### PR TITLE
Hide modal on load and add start over in report designer

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -11,6 +11,13 @@
     themeSwitch.addEventListener('change', ()=> setTheme(themeSwitch.checked ? 'light' : 'dark'));
   }
 
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.modal').forEach(m => {
+      m.classList.remove('show');
+      m.style.display = 'none';
+    });
+  });
+
   window.exportTableToPDF = function(tableId, title){
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'letter'});

--- a/web/public/pages/items.php
+++ b/web/public/pages/items.php
@@ -96,7 +96,7 @@ if($variantView==='grouped'){
 </tr><?php endforeach; ?>
 </tbody></table></div></div></div></div></div>
 
-<div class="modal fade" id="addItemModal" tabindex="-1" aria-labelledby="addItemModalLabel" aria-hidden="true">
+<div class="modal fade" id="addItemModal" tabindex="-1" aria-labelledby="addItemModalLabel" aria-hidden="true" style="display:none;">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <form method="post" enctype="multipart/form-data">

--- a/web/public/pages/report_designer.php
+++ b/web/public/pages/report_designer.php
@@ -7,6 +7,7 @@
 table.report-preview th, table.report-preview td { border:1px solid #ccc; padding:4px; }
 table.report-preview th { background:#eee; }</textarea>
     <button class="btn btn-primary mt-2" onclick="updatePreview()">Update Preview</button>
+    <button class="btn btn-outline-secondary mt-2 ms-2" onclick="resetDesigner()">Start Over</button>
   </div>
   <div class="col-md-6">
     <h2 class="h6">Preview</h2>
@@ -20,9 +21,24 @@ table.report-preview th { background:#eee; }</textarea>
 </div>
 <style id="designerStyles"></style>
 <script>
+const defaultCSS = `table.report-preview { width:100%; border-collapse:collapse; }
+table.report-preview th, table.report-preview td { border:1px solid #ccc; padding:4px; }
+table.report-preview th { background:#eee; }`;
+const defaultTable = `<table class="report-preview">
+  <thead><tr><th>SKU</th><th>Name</th><th>Qty</th></tr></thead>
+  <tbody><tr><td>ABC123</td><td>Sample Part</td><td>10</td></tr></tbody>
+</table>`;
+
 function updatePreview(){
   document.getElementById('designerStyles').textContent = document.getElementById('cssInput').value;
 }
+
+function resetDesigner(){
+  document.getElementById('cssInput').value = defaultCSS;
+  document.getElementById('preview').innerHTML = defaultTable;
+  updatePreview();
+}
+
 updatePreview();
 </script>
 


### PR DESCRIPTION
## Summary
- ensure Bootstrap modals are hidden when the page loads
- add Start Over button to reset report designer inputs and preview

## Testing
- `php -l web/public/pages/items.php`
- `php -l web/public/pages/report_designer.php`
- `node --check web/public/assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb92d3065083299e0f0b4527902214